### PR TITLE
Handle {error, closed} on tcp connection when fetching response

### DIFF
--- a/src/mysql_protocol.erl
+++ b/src/mysql_protocol.erl
@@ -118,7 +118,7 @@ handshake_finish_or_switch_auth(Handshake, Password, SockModule, Socket, SeqNum)
 %% If the authentication process requires more data to be exchanged between
 %% the server and client, this is done via More Data Packets. The formats and
 %% meanings of the payloads in such packets depend on the auth method.
-%% 
+%%
 %% An Auth Method Switch Packet signals a request for transition to another
 %% auth method. The packet contains the name of the auth method to switch to,
 %% and new auth plugin data.
@@ -550,7 +550,7 @@ parse_handshake_confirm(<<?MORE_DATA, MoreData/binary>>) ->
 %% prepared statements).
 -spec fetch_response(module(), term(), timeout(), text | binary, [binary()],
                      query_filtermap(), list()) ->
-    {ok, [#ok{} | #resultset{} | #error{}]} | {error, timeout}.
+    {ok, [#ok{} | #resultset{} | #error{}]} | {error, timeout} | {error, closed} .
 fetch_response(SockModule, Socket, Timeout, Proto, AllowedPaths, FilterMap, Acc) ->
     case recv_packet(SockModule, Socket, Timeout, any) of
         {ok, ?local_infile_pattern = Packet, SeqNum2} ->
@@ -592,7 +592,9 @@ fetch_response(SockModule, Socket, Timeout, Proto, AllowedPaths, FilterMap, Acc)
                     {ok, lists:reverse(Acc1)}
             end;
         {error, timeout} ->
-            {error, timeout}
+            {error, timeout};
+        {error, closed} ->
+            {error, closed}
     end.
 
 %% @doc Fetches a result set.


### PR DESCRIPTION
This PR fixes handling of tcp error returned when socket is closed in mysq_protocol:fetch_response/7.

Following error was present:
```
exception error: {{case_clause,{{{case_clause,{error,closed}},[{mysql_protocol,fetch_response,6,[{file,"_build/default/lib/mysql/src/mysql_protocol.erl"},{line,564}]},{mysql_conn,execute_stmt,5,[{file,"_build/default/lib/mysql/src/mysql_conn.erl"},{line,546}]},{mysql_conn,handle_call,3,[{file,"_build/default/lib/mysql/src/mysql_conn.erl"},{line,338}]}
```

Version: 1.7